### PR TITLE
[all] multithreading

### DIFF
--- a/flatpak/dev.cstring.mixologist.yml
+++ b/flatpak/dev.cstring.mixologist.yml
@@ -21,6 +21,19 @@ build-options:
   prepend-ld-library-path: /usr/lib/sdk/llvm20/lib
 modules:
   - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
+  - name: pipewire
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://gitlab.freedesktop.org/pipewire/pipewire.git
+        tag: "1.4"
+    config-opts:
+      - "-Dsystemd=disabled"
+      - "-Dudev=disabled"
+      - "-Dalsa=disabled"
+      - "-Ddocs=disabled"
+      - "-Dtests=disabled"
+      - "-Dsession-managers=[]"
   - name: SDL3
     buildsystem: cmake-ninja
     builddir: true

--- a/pipewire/pipewire_procs.odin
+++ b/pipewire/pipewire_procs.odin
@@ -42,6 +42,11 @@ foreign pipewire {
 	thread_loop_accept :: proc(loop: ^thread_loop) ---
 	thread_loop_in_thread :: proc(loop: ^thread_loop) -> bool ---
 
+	loop_new :: proc(props: ^spa_dict) -> ^loop ---
+	loop_destroy :: proc(loop: ^loop) ---
+	loop_set_name :: proc(loop: ^loop, name: cstring) ---
+	loop_invoke :: proc(object: ^loop, func: spa_invoke_func_t, seq: u32, data: rawptr, size: uint, block: bool, user_data: rawptr) -> i32 ---
+
 	context_new :: proc(main_loop: ^loop, props: ^properties, user_data_size: uint) -> ^pw_context ---
 	context_destroy :: proc(ctx: ^pw_context) ---
 	context_load_module :: proc(ctx: ^pw_context, name: cstring, args: cstring, properties: ^properties) -> ^impl_module ---

--- a/pipewire/pipewire_structs.odin
+++ b/pipewire/pipewire_structs.odin
@@ -40,10 +40,10 @@ thread_loop :: struct {
 thread_loop_events :: struct {} // [TODO] fill out fields
 
 loop :: struct {
-	system:  rawptr,
-	loop:    rawptr,
-	control: rawptr,
-	utils:   rawptr,
+	system:  ^spa_system,
+	loop:    ^spa_loop,
+	control: ^spa_loop_control,
+	utils:   ^spa_loop_utils,
 	name:    cstring,
 }
 

--- a/pipewire/spa.odin
+++ b/pipewire/spa.odin
@@ -28,6 +28,22 @@ spa_support :: struct {
 	data: rawptr,
 }
 
+spa_system :: struct {
+	iface: spa_interface,
+}
+
+spa_loop :: struct {
+	iface: spa_interface,
+}
+
+spa_loop_control :: struct {
+	iface: spa_interface,
+}
+
+spa_loop_utils :: struct {
+	iface: spa_interface,
+}
+
 spa_hook :: struct {
 	link:    spa_list,
 	cb:      spa_callbacks,
@@ -61,6 +77,15 @@ spa_command :: struct {
 spa_command_body :: struct {
 	body: spa_pod_object_body,
 }
+
+spa_invoke_func_t :: #type proc "c" (
+	loop: ^loop,
+	async: bool,
+	seq: u32,
+	data: rawptr,
+	size: uint,
+	user_data: rawptr,
+) -> i32
 
 spa_prop_info :: enum u32 {
 	SPA_PROP_INFO_START,

--- a/src/daemon.odin
+++ b/src/daemon.odin
@@ -495,5 +495,5 @@ daemon_set_volumes :: proc(ctx: ^Daemon_Context, volumes: [2]f32) {
 	log.debugf("setting pipewire volumes: %v", volumes)
 	volumes_ptr := new([2]f32, context.allocator)
 	volumes_ptr^ = volumes
-	pw.loop_invoke(ctx.loop, daemon_invoke_set_volume, 0, volumes_ptr, 0, false, volumes_ptr)
+	pw.loop_invoke(ctx.loop, daemon_invoke_set_volume, 0, nil, 0, false, volumes_ptr)
 }

--- a/src/daemon.odin
+++ b/src/daemon.odin
@@ -473,7 +473,7 @@ daemon_remove_program :: proc(ctx: ^Daemon_Context, program: string) {
 	}
 }
 
-invoke_set_volume :: proc "c" (
+daemon_invoke_set_volume :: proc "c" (
 	loop: ^pw.loop,
 	async: bool,
 	seq: u32,
@@ -495,5 +495,5 @@ daemon_set_volumes :: proc(ctx: ^Daemon_Context, volumes: [2]f32) {
 	log.debugf("setting pipewire volumes: %v", volumes)
 	volumes_ptr := new([2]f32, context.allocator)
 	volumes_ptr^ = volumes
-	pw.loop_invoke(ctx.loop, invoke_set_volume, 0, volumes_ptr, 0, false, volumes_ptr)
+	pw.loop_invoke(ctx.loop, daemon_invoke_set_volume, 0, volumes_ptr, 0, false, volumes_ptr)
 }

--- a/src/daemon.odin
+++ b/src/daemon.odin
@@ -37,6 +37,16 @@ Daemon_Context :: struct {
 	should_exit:       bool,
 }
 
+daemon_proc :: proc(ctx: ^Daemon_Context) {
+	daemon_init(&mixologist.daemon)
+	for !daemon_should_exit(&mixologist.daemon) {
+		daemon_tick(&mixologist.daemon)
+		free_all(context.temp_allocator)
+	}
+	daemon_deinit(&mixologist.daemon)
+	mixologist_event_send(Exit{})
+}
+
 daemon_init :: proc(ctx: ^Daemon_Context) {
 	if virtual.arena_init_growing(&ctx.arena) != nil {
 		panic("Couldn't initialize arena")
@@ -93,7 +103,7 @@ daemon_init :: proc(ctx: ^Daemon_Context) {
 daemon_tick :: proc(ctx: ^Daemon_Context) {
 	// this is a no-op but here for the future
 	time: linux.Time_Spec
-	pw.thread_loop_get_time(ctx.main_loop, &time, 1e4)
+	pw.thread_loop_get_time(ctx.main_loop, &time, 1e6)
 	pw.thread_loop_timed_wait_full(ctx.main_loop, &time)
 }
 

--- a/src/daemon.odin
+++ b/src/daemon.odin
@@ -496,3 +496,9 @@ daemon_set_volumes :: proc(ctx: ^Daemon_Context, volumes: [2]f32) {
 	volumes_ptr^ = volumes
 	pw.loop_invoke(ctx.loop, daemon_invoke_set_volume, 0, nil, 0, false, volumes_ptr)
 }
+
+daemon_signal_stop :: proc(ctx: ^Daemon_Context) {
+	log.info("daemon signaling stop")
+	pw.main_loop_quit(ctx.main_loop)
+	ctx.should_exit = true
+}

--- a/src/daemon.odin
+++ b/src/daemon.odin
@@ -16,7 +16,7 @@ Daemon_Context :: struct {
 	config_file:       string,
 	cache_file:        string,
 	// pipewire required state
-	main_loop:         ^pw.thread_loop,
+	main_loop:         ^pw.main_loop,
 	loop:              ^pw.loop,
 	core:              ^pw.core,
 	pw_context:        ^pw.pw_context,
@@ -38,13 +38,12 @@ Daemon_Context :: struct {
 }
 
 daemon_proc :: proc(ctx: ^Daemon_Context) {
+	log.info("daemon starting")
 	daemon_init(&mixologist.daemon)
-	for !daemon_should_exit(&mixologist.daemon) {
-		daemon_tick(&mixologist.daemon)
-		free_all(context.temp_allocator)
-	}
+	pw.main_loop_run(ctx.main_loop)
 	daemon_deinit(&mixologist.daemon)
-	mixologist_event_send(Exit{})
+	log.info("daemon exiting")
+	mixologist_should_exit()
 }
 
 daemon_init :: proc(ctx: ^Daemon_Context) {
@@ -69,10 +68,9 @@ daemon_init :: proc(ctx: ^Daemon_Context) {
 			pw.get_client_name(),
 		)
 
-		ctx.main_loop = pw.thread_loop_new("main", nil)
+		ctx.main_loop = pw.main_loop_new(nil)
 
-		pw.thread_loop_lock(ctx.main_loop)
-		ctx.loop = pw.thread_loop_get_loop(ctx.main_loop)
+		ctx.loop = pw.main_loop_get_loop(ctx.main_loop)
 
 		// required for flatpak volume control
 		ctx.pw_context_props = pw.properties_new(nil, nil)
@@ -96,21 +94,10 @@ daemon_init :: proc(ctx: ^Daemon_Context) {
 	}
 
 	setup_exit_handlers(ctx)
-	pw.thread_loop_start(ctx.main_loop)
 }
 
-
-daemon_tick :: proc(ctx: ^Daemon_Context) {
-	// this is a no-op but here for the future
-	time: linux.Time_Spec
-	pw.thread_loop_get_time(ctx.main_loop, &time, 1e6)
-	pw.thread_loop_timed_wait_full(ctx.main_loop, &time)
-}
 
 daemon_deinit :: proc(ctx: ^Daemon_Context) {
-	pw.thread_loop_unlock(ctx.main_loop)
-	pw.thread_loop_stop(ctx.main_loop)
-
 	// pipewire cleanup
 	{
 		reset_links(ctx)
@@ -119,10 +106,13 @@ daemon_deinit :: proc(ctx: ^Daemon_Context) {
 		pw.proxy_destroy(cast(^pw.proxy)ctx.registry)
 		pw.core_disconnect(ctx.core)
 		pw.context_destroy(ctx.pw_context)
-		pw.thread_loop_destroy(ctx.main_loop)
+		pw.main_loop_destroy(ctx.main_loop)
 		pw.deinit()
 	}
 
+	for input in ctx.device_inputs {
+		delete(input)
+	}
 	free_all(ctx.allocator)
 }
 
@@ -144,8 +134,8 @@ do_quit_with_data :: proc "c" (signum: posix.Signal, data: rawptr) {
 		ctx = cast(^Daemon_Context)data
 		return
 	}
-	pw.thread_loop_signal(ctx.main_loop, false)
-	ctx.should_exit = true
+	pw.main_loop_quit(ctx.main_loop)
+	mixologist_signal_exit()
 }
 
 registry_events := pw.registry_events {
@@ -218,14 +208,14 @@ node_handler :: proc(ctx: ^Daemon_Context, id, version: u32, type: cstring, prop
 		proxy := pw.registry_bind(ctx.registry, id, type, version, 0)
 		node: Node
 		name_str := strings.clone_from_cstring(node_name)
-		node_init(&node, proxy, props, name_str, ctx.allocator)
+		node_init(&node, proxy, props, name_str)
 		ctx.default_sink.loopback_node = node
 		log.logf(.Info, "registered default node with id %d", id)
 	} else if node_name == "output.mixologist-aux" {
 		proxy := pw.registry_bind(ctx.registry, id, type, version, 0)
 		node: Node
 		name_str := strings.clone_from_cstring(node_name)
-		node_init(&node, proxy, props, name_str, ctx.allocator)
+		node_init(&node, proxy, props, name_str)
 		ctx.aux_sink.loopback_node = node
 		log.logf(.Info, "registered aux node with id %d", id)
 	} else {
@@ -239,7 +229,7 @@ node_handler :: proc(ctx: ^Daemon_Context, id, version: u32, type: cstring, prop
 			proxy := pw.registry_bind(ctx.registry, id, type, version, 0)
 			node: Node
 			name_str := strings.clone_from_cstring(node_name)
-			node_init(&node, proxy, props, name_str, ctx.allocator)
+			node_init(&node, proxy, props, name_str)
 			ctx.passthrough_nodes[id] = node
 			return
 		} else if media_class != "Stream/Output/Audio" {
@@ -249,7 +239,7 @@ node_handler :: proc(ctx: ^Daemon_Context, id, version: u32, type: cstring, prop
 		proxy := pw.registry_bind(ctx.registry, id, type, version, 0)
 		node: Node
 		name_str := strings.clone_from_cstring(node_name)
-		node_init(&node, proxy, props, name_str, ctx.allocator)
+		node_init(&node, proxy, props, name_str)
 		if daemon_rule_matches(ctx, string(application_name)) {
 			ctx.aux_sink.associated_nodes[id] = node
 		} else {
@@ -481,4 +471,29 @@ daemon_remove_program :: proc(ctx: ^Daemon_Context, program: string) {
 			}
 		}
 	}
+}
+
+invoke_set_volume :: proc "c" (
+	loop: ^pw.loop,
+	async: bool,
+	seq: u32,
+	data: rawptr,
+	size: uint,
+	user_data: rawptr,
+) -> i32 {
+	volumes := cast(^[2]f32)user_data
+	daemon_ctx := mixologist.daemon
+	context = daemon_ctx.pw_odin_ctx
+	log.debugf("volume callback executed: %v", volumes)
+	sink_set_volume(&daemon_ctx.default_sink, volumes[0])
+	sink_set_volume(&daemon_ctx.aux_sink, volumes[1])
+	free(volumes)
+	return 0
+}
+
+daemon_set_volumes :: proc(ctx: ^Daemon_Context, volumes: [2]f32) {
+	log.debugf("setting pipewire volumes: %v", volumes)
+	volumes_ptr := new([2]f32, context.allocator)
+	volumes_ptr^ = volumes
+	pw.loop_invoke(ctx.loop, invoke_set_volume, 0, volumes_ptr, 0, false, volumes_ptr)
 }

--- a/src/daemon.odin
+++ b/src/daemon.odin
@@ -7,7 +7,6 @@ import "core:mem"
 import "core:mem/virtual"
 import "core:strconv"
 import "core:strings"
-import "core:sys/linux"
 import "core:sys/posix"
 import "core:text/match"
 

--- a/src/gui.odin
+++ b/src/gui.odin
@@ -1,6 +1,7 @@
 package mixologist
 
 import "./clay"
+import "core:log"
 import "core:slice"
 import "core:strings"
 
@@ -31,13 +32,15 @@ GUI_Context :: struct {
 }
 
 gui_proc :: proc(ctx: ^GUI_Context) {
+	log.info("gui starting")
 	gui_init(&mixologist.gui, mixologist.config.settings.start_minimized)
-	for !UI_should_exit(&mixologist.gui.ui_ctx) {
+	for !(UI_should_exit(&mixologist.gui.ui_ctx) || mixologist_should_exit()) {
 		gui_tick(&mixologist.gui)
 		free_all(context.temp_allocator)
 	}
 	gui_deinit(&mixologist.gui)
-	mixologist_event_send(Exit{})
+	log.info("gui exiting")
+	mixologist_signal_exit()
 }
 
 gui_init :: proc(ctx: ^GUI_Context, minimized: bool) {
@@ -80,7 +83,6 @@ UI_create_layout :: proc(
 ) -> clay.ClayArray(clay.RenderCommand) {
 	mgst_ctx := cast(^GUI_Context)userdata
 	layout := create_layout(mgst_ctx)
-	mixologist_process_events(&mixologist)
 	return layout
 }
 

--- a/src/main.odin
+++ b/src/main.odin
@@ -319,6 +319,7 @@ main :: proc() {
 	}
 
 	if .Daemon in mixologist.statuses {
+		daemon_signal_stop(&mixologist.daemon)
 		thread.join(mixologist.daemon_thread)
 	}
 

--- a/src/main.odin
+++ b/src/main.odin
@@ -10,32 +10,38 @@ import "core:fmt"
 import "core:log"
 @(require) import "core:mem"
 import "core:os/os2"
+import "core:slice"
 import "core:strconv"
 import "core:strings"
+import "core:sync"
 import "core:sys/linux"
+import "core:thread"
 import "core:time"
 
 Mixologist :: struct {
 	// state
-	statuses:    Statuses,
-	events:      [dynamic]Event,
-	programs:    [dynamic]string,
+	statuses:      Statuses,
+	events:        [dynamic]Event,
+	programs:      [dynamic]string,
+	event_mutex:   sync.Mutex,
 	// inotify
-	fd:          linux.Fd,
-	wd:          linux.Wd,
-	buf:         [EVENT_BUF_LEN]u8,
+	fd:            linux.Fd,
+	wd:            linux.Wd,
+	buf:           [EVENT_BUF_LEN]u8,
 	// ipc
-	ipc:         IPC_Server_Context,
+	ipc:           IPC_Server_Context,
 	// subapp states
-	daemon:      Daemon_Context,
-	gui:         GUI_Context,
-	shortcuts:   GlobalShortcuts_Session,
+	daemon:        Daemon_Context,
+	daemon_thread: ^thread.Thread,
+	gui:           GUI_Context,
+	gui_thread:    ^thread.Thread,
+	shortcuts:     GlobalShortcuts_Session,
 	// config
-	config_dir:  string,
-	cache_dir:   string,
-	volume_file: string,
-	config:      Config,
-	volume:      f32,
+	config_dir:    string,
+	cache_dir:     string,
+	volume_file:   string,
+	config:        Config,
+	volume:        f32,
 }
 
 Config :: struct {
@@ -93,14 +99,20 @@ Status :: enum {
 }
 
 Event :: union {
+	Exit,
 	Rule_Add,
 	Rule_Remove,
 	Rule_Update,
+	Program_Add,
+	Program_Remove,
 	Volume,
 	Settings,
 }
+Exit :: struct {}
 Rule_Add :: distinct string
 Rule_Remove :: distinct string
+Program_Add :: distinct string
+Program_Remove :: distinct string
 Rule_Update :: struct {
 	prev: string,
 	cur:  string,
@@ -252,11 +264,14 @@ main :: proc() {
 
 	// init app state
 	if .Daemon in mixologist.statuses {
-		daemon_init(&mixologist.daemon)
+		mixologist.daemon_thread = thread.create_and_start_with_poly_data(
+			&mixologist.daemon,
+			daemon_proc,
+		)
 	}
 
 	if .Gui in mixologist.statuses {
-		gui_init(&mixologist.gui, mixologist.config.settings.start_minimized)
+		mixologist.gui_thread = thread.create_and_start_with_poly_data(&mixologist.gui, gui_proc)
 	}
 
 	for (.Exit not_in mixologist.statuses) {
@@ -291,33 +306,16 @@ main :: proc() {
 			Portals_Tick(mixologist.shortcuts.conn)
 			mixologist_process_events(&mixologist)
 		}
-
-		if .Daemon in mixologist.statuses {
-			daemon_tick(&mixologist.daemon)
-			mixologist_process_events(&mixologist)
-			if daemon_should_exit(&mixologist.daemon) {
-				mixologist.statuses += {.Exit}
-			}
-		}
-
-		if .Gui in mixologist.statuses {
-			gui_tick(&mixologist.gui)
-			if UI_should_exit(&mixologist.gui.ui_ctx) {
-				mixologist.statuses += {.Exit}
-			}
-		} else {
-			time.sleep(time.Millisecond / 2)
-		}
-
+		time.sleep(time.Millisecond / 10)
 		free_all(context.temp_allocator)
 	}
 
 	if .Daemon in mixologist.statuses {
-		daemon_deinit(&mixologist.daemon)
+		thread.join(mixologist.daemon_thread)
 	}
 
 	if .Gui in mixologist.statuses {
-		gui_deinit(&mixologist.gui)
+		thread.join(mixologist.gui_thread)
 	}
 
 	if .GlobalShortcuts in mixologist.statuses {
@@ -388,10 +386,31 @@ mixologist_process_events :: proc(mixologist: ^Mixologist) {
 			log.debugf("settings changed: %v", event)
 			mixologist.config.settings = event
 			mixologist_config_write(mixologist)
+		case Program_Add:
+			log.infof("adding program %s", event)
+			append(&mixologist.programs, string(event))
+		case Program_Remove:
+			log.infof("removing program %s", event)
+			node_idx, found := slice.linear_search(mixologist.programs[:], string(event))
+			if found {
+				delete(mixologist.programs[node_idx])
+				unordered_remove(&mixologist.programs, node_idx)
+			}
+		case Exit:
+			mixologist.statuses += {.Exit}
+			mixologist.gui.ui_ctx.statuses += {.APP_EXIT}
+			mixologist.daemon.should_exit = true
+			break
 		}
 		mixologist.gui.ui_ctx.statuses += {.DIRTY}
 	}
 	clear(&mixologist.events)
+}
+
+mixologist_event_send :: proc(event: Event) {
+	if sync.mutex_guard(&mixologist.event_mutex) {
+		append(&mixologist.events, event)
+	}
 }
 
 mixologist_ipc_messages :: proc(mixologist: ^Mixologist) {
@@ -412,12 +431,12 @@ mixologist_ipc_messages :: proc(mixologist: ^Mixologist) {
 				IPC_Server_send(&mixologist.ipc, sender, vol)
 			case .Set:
 				log.debugf("setting volume %v: socket %v", msg.val, sender)
-				append(&mixologist.events, msg.val)
+				mixologist_event_send(msg.val)
 				IPC_Server_notify_volume_subscription(&mixologist.ipc, mixologist.volume)
 			case .Shift:
 				log.debugf("shifting volume %v: socket %v", msg.val, sender)
 				vol := mixologist.volume + msg.val
-				append(&mixologist.events, vol)
+				mixologist_event_send(vol)
 				IPC_Server_notify_volume_subscription(&mixologist.ipc, mixologist.volume)
 			case .Subscribe:
 				log.debugf("subscribing volume: socket %v", sender)
@@ -432,11 +451,11 @@ mixologist_ipc_messages :: proc(mixologist: ^Mixologist) {
 			switch msg.act {
 			case .Add:
 				log.infof("adding program %s", msg.val)
-				append(&mixologist.events, Rule_Add(msg.val))
+				mixologist_event_send(Rule_Add(msg.val))
 			// [TODO] implement program subscriptions
 			case .Remove:
 				log.infof("removing program %s", msg.val)
-				append(&mixologist.events, Rule_Remove(msg.val))
+				mixologist_event_send(Rule_Remove(msg.val))
 			// [TODO] implement program subscriptions
 			case .Subscribe:
 				IPC_Server_add_program_subscriber(&mixologist.ipc, sender)
@@ -535,16 +554,16 @@ mixologist_globalshortcuts_handler :: proc "c" (
 		switch shortcut_id {
 		case .RAISE:
 			vol := mixologist.volume + 0.1
-			append(&mixologist.events, vol)
+			mixologist_event_send(vol)
 		case .LOWER:
 			vol := mixologist.volume - 0.1
-			append(&mixologist.events, vol)
+			mixologist_event_send(vol)
 		case .MAX:
-			append(&mixologist.events, 1)
+			mixologist_event_send(1)
 		case .MIN:
-			append(&mixologist.events, -1)
+			mixologist_event_send(-1)
 		case .RESET:
-			append(&mixologist.events, 0)
+			mixologist_event_send(0)
 		}
 		return .HANDLED
 	}

--- a/src/renderer.odin
+++ b/src/renderer.odin
@@ -399,7 +399,14 @@ Renderer_draw :: proc(
 	// render
 	swapchain_texture: ^sdl.GPUTexture
 	w, h: u32
-	_ = sdl.WaitAndAcquireGPUSwapchainTexture(cmd_buffer, ctx.window, &swapchain_texture, &w, &h)
+	if !sdl.WaitAndAcquireGPUSwapchainTexture(cmd_buffer, ctx.window, &swapchain_texture, &w, &h) {
+		log.error("failed to acquire swapchain texture")
+		return
+	}
+	if swapchain_texture == nil {
+		log.error("swapchain texture is nil")
+		return
+	}
 
 	if swapchain_texture != nil {
 		render_pass := sdl.BeginGPURenderPass(

--- a/src/renderer.odin
+++ b/src/renderer.odin
@@ -9,7 +9,9 @@ import sdl "vendor:sdl3"
 import ttf "vendor:sdl3/ttf"
 
 BUFFER_INIT_SIZE :: 128
+@(thread_local)
 pipeline: Pipeline
+@(thread_local)
 commands: [dynamic]Command
 
 Pipeline_Status :: enum {
@@ -588,10 +590,10 @@ ortho_rh :: proc(
 	far: f32,
 ) -> matrix[4, 4]f32 {
 	return matrix[4, 4]f32{
-		2.0 / (right - left), 0.0, 0.0, -(right + left) / (right - left), 
-		0.0, 2.0 / (top - bottom), 0.0, -(top + bottom) / (top - bottom), 
-		0.0, 0.0, -2.0 / (far - near), -(far + near) / (far - near), 
-		0.0, 0.0, 0.0, 1.0, 
+		2.0 / (right - left), 0.0, 0.0, -(right + left) / (right - left),
+		0.0, 2.0 / (top - bottom), 0.0, -(top + bottom) / (top - bottom),
+		0.0, 0.0, -2.0 / (far - near), -(far + near) / (far - near),
+		0.0, 0.0, 0.0, 1.0,
 	}
 }
 

--- a/src/sink.odin
+++ b/src/sink.odin
@@ -7,7 +7,6 @@ import "core:log"
 import "core:math"
 import "core:mem/virtual"
 import "core:os/os2"
-import "core:slice"
 import "core:strings"
 
 DEFAULT_MAP_CAPACITY :: #config(DEFAULT_MAP_CAPACITY, 128)
@@ -89,7 +88,7 @@ node_init :: proc(
 	node.name = name
 
 	if name != "output.mixologist-default" && name != "output.mixologist-aux" {
-		append(&mixologist.programs, node.name)
+		mixologist_event_send(Program_Add(strings.clone(node.name)))
 	}
 }
 
@@ -98,8 +97,7 @@ node_destroy :: proc(node: ^Node) {
 		delete(channel)
 	}
 	log.info("destroying node: %v", node.name)
-	node_idx, found := slice.linear_search(mixologist.programs[:], node.name)
-	if found do unordered_remove(&mixologist.programs, node_idx)
+	mixologist_event_send(Program_Remove(node.name))
 
 	pw.proxy_destroy(node.proxy)
 	delete(node.name)

--- a/src/sink.odin
+++ b/src/sink.odin
@@ -1,7 +1,6 @@
 package mixologist
 
 import pw "../pipewire"
-import "base:runtime"
 import "core:fmt"
 import "core:log"
 import "core:math"

--- a/src/ui.odin
+++ b/src/ui.odin
@@ -480,6 +480,8 @@ UI_tick :: proc(
 			sdl.ReleaseGPUFence(ctx.device, fence)
 		}
 		ctx.prev_event_time = time.tick_now()
+	} else {
+		time.sleep(ctx.prev_frametime)
 	}
 
 	when ODIN_DEBUG {

--- a/src/ui.odin
+++ b/src/ui.odin
@@ -51,9 +51,10 @@ UI_Context :: struct {
 	// sdl3
 	window:              ^sdl.Window,
 	window_size:         [2]c.float,
-	start_time:          time.Time,
-	prev_frame_time:     time.Time,
-	prev_event_time:     time.Time,
+	start_time:          time.Tick,
+	prev_frame_time:     time.Tick,
+	prev_frametime:      time.Duration,
+	prev_event_time:     time.Tick,
 	scaling:             c.float,
 	tray:                ^sdl.Tray,
 	tray_menu:           ^sdl.TrayMenu,
@@ -106,7 +107,7 @@ UI_Data_Flags :: bit_set[UI_Data_Flag;uintptr]
 UI_DOUBLE_CLICK_INTERVAL :: 300 * time.Millisecond
 UI_EVENT_DELAY :: 33 * time.Millisecond
 DEBUG_LAYOUT_TIMER_INTERVAL :: time.Second
-UI_DEBUG_PREV_TIME: time.Time
+UI_DEBUG_PREV_TIME: time.Tick
 
 UI_Context_Status :: enum {
 	DIRTY,
@@ -203,7 +204,7 @@ UI_init :: proc(ctx: ^UI_Context, minimized: bool) {
 	ctx.textbox_state.set_clipboard = UI__set_clipboard
 	ctx.textbox_state.get_clipboard = UI__get_clipboard
 	ctx.textbox_input = strings.builder_from_bytes(ctx._text_store[:])
-	ctx.start_time = time.now()
+	ctx.start_time = time.tick_now()
 
 	min_mem := c.size_t(clay.MinMemorySize())
 	ctx.clay_memory = make([]u8, min_mem)
@@ -272,8 +273,11 @@ UI_init :: proc(ctx: ^UI_Context, minimized: bool) {
 	)
 
 	clay.SetMeasureTextFunction(UI__measure_text, ctx)
-	ctx.prev_event_time = time.now()
-	ctx.prev_frame_time = time.now()
+	ctx.prev_event_time = time.tick_now()
+	ctx.prev_frame_time = time.tick_now()
+
+	// reasonable 60fps default for initial redraw rate
+	ctx.prev_frametime = 16 * time.Millisecond
 }
 
 UI_deinit :: proc(ctx: ^UI_Context) {
@@ -300,6 +304,7 @@ UI_tick :: proc(
 	) -> clay.ClayArray(clay.RenderCommand),
 	userdata: rawptr,
 ) {
+	frame_start := time.tick_now()
 	// input reset
 	{
 		strings.builder_reset(&ctx.textbox_input)
@@ -317,9 +322,7 @@ UI_tick :: proc(
 		case .QUIT:
 			ctx.statuses += {.APP_EXIT}
 		case .WINDOW_CLOSE_REQUESTED:
-			ctx.statuses += {.WINDOW_CLOSED}
-			sdl.SetTrayEntryLabel(ctx.toggle_entry, "Open")
-			sdl.HideWindow(ctx.window)
+			UI_toggle_window(ctx, ctx.toggle_entry)
 		case .WINDOW_DISPLAY_SCALE_CHANGED:
 			ctx.statuses += {.EVENT}
 			ctx.scaling = sdl.GetWindowDisplayScale(ctx.window)
@@ -389,6 +392,7 @@ UI_tick :: proc(
 	// [INFO] sdl.WaitAndAcquireGPUSwapchainTexture will hang if
 	// we do not return early
 	if .WINDOW_CLOSED in ctx.statuses {
+		time.sleep(16 * time.Millisecond)
 		return
 	}
 
@@ -442,13 +446,13 @@ UI_tick :: proc(
 	clay.UpdateScrollContainers(
 		false,
 		ctx.scroll_delta * 5,
-		c.float(time.since(ctx.prev_frame_time) / time.Second),
+		c.float(time.tick_since(ctx.prev_frame_time) / time.Second),
 	)
 	render_commands := ui_create_layout(ctx, userdata)
 
 	when ODIN_DEBUG {
 		layout_time := time.since(layout_start)
-		render_start := time.now()
+		render_start := time.tick_now()
 	}
 
 	if ctx.hovered_widget != ctx.prev_hovered_widget do ctx.statuses += {.EVENT}
@@ -469,19 +473,23 @@ UI_tick :: proc(
 		cmd_buffer := sdl.AcquireGPUCommandBuffer(ctx.device)
 		Renderer_draw(ctx, cmd_buffer, &render_commands)
 		fence := sdl.SubmitGPUCommandBufferAndAcquireFence(cmd_buffer)
-		_ = sdl.WaitForGPUFences(ctx.device, true, &fence, 1)
-		sdl.ReleaseGPUFence(ctx.device, fence)
-		ctx.prev_event_time = time.now()
+		if fence == nil {
+			log.error("fence is nil")
+		} else {
+			_ = sdl.WaitForGPUFences(ctx.device, true, &fence, 1)
+			sdl.ReleaseGPUFence(ctx.device, fence)
+		}
+		ctx.prev_event_time = time.tick_now()
 	}
 
 	when ODIN_DEBUG {
 		ctx.statuses += {.DIRTY}
-		render_time := time.since(render_start)
+		render_time := time.tick_since(render_start)
 		if clay.IsDebugModeEnabled() {
-			if time.since(UI_DEBUG_PREV_TIME) > DEBUG_LAYOUT_TIMER_INTERVAL {
+			if time.tick_since(UI_DEBUG_PREV_TIME) > DEBUG_LAYOUT_TIMER_INTERVAL {
 				fmt.printfln(
 					"FPS: %.2f",
-					1 / time.duration_seconds(time.since(ctx.prev_frame_time)),
+					1 / time.duration_seconds(time.tick_since(ctx.prev_frame_time)),
 				)
 				fmt.println("Layout time:", layout_time)
 				fmt.println("Render time:", render_time)
@@ -490,14 +498,13 @@ UI_tick :: proc(
 				fmt.println("Mouse scroll:", ctx.scroll_delta)
 				fmt.println("Display scale:", ctx.scaling)
 				fmt.println("Statuses:", ctx.statuses)
-				UI_DEBUG_PREV_TIME = time.now()
+				UI_DEBUG_PREV_TIME = time.tick_now()
 			}
 		}
-	} else {
-		time.sleep(time.Millisecond / 10)
 	}
 
-	ctx.prev_frame_time = time.now()
+	ctx.prev_frame_time = time.tick_now()
+	ctx.prev_frametime = time.tick_since(frame_start)
 }
 
 UI_open_window :: proc(ctx: ^UI_Context) {
@@ -700,7 +707,7 @@ UI_scrollbar :: proc(
 		active = true
 	}
 	if active && .LEFT in ctx.mouse_down {
-		if time.since(ctx.prev_event_time) > UI_EVENT_DELAY do ctx.statuses += {.EVENT}
+		if time.tick_since(ctx.prev_event_time) > UI_EVENT_DELAY do ctx.statuses += {.EVENT}
 		res += {.CHANGE}
 
 		data := clay.GetElementData(id)
@@ -820,7 +827,7 @@ UI_slider :: proc(
 		}
 	}
 
-	if .CHANGE in res && time.since(ctx.prev_event_time) > UI_EVENT_DELAY do ctx.statuses += {.EVENT}
+	if .CHANGE in res && time.tick_since(ctx.prev_event_time) > UI_EVENT_DELAY do ctx.statuses += {.EVENT}
 	return
 }
 
@@ -1322,7 +1329,7 @@ UI__textbox :: proc(
 									1,
 									1,
 									((math.sin(
-												c.float(time.since(ctx.start_time)) /
+												c.float(time.tick_since(ctx.start_time)) /
 												c.float(250 * time.Millisecond),
 											)) +
 										1) /
@@ -1330,7 +1337,7 @@ UI__textbox :: proc(
 								},
 						},
 						) {
-							if time.since(ctx.prev_event_time) > UI_EVENT_DELAY do ctx.statuses += {.EVENT}
+							if time.tick_since(ctx.prev_event_time) > UI_EVENT_DELAY do ctx.statuses += {.EVENT}
 						}
 					} else { 	// selection box
 						x_offset := f32(ctx.textbox_offset) + min(head_size.width, tail_size.width)
@@ -1354,7 +1361,7 @@ UI__textbox :: proc(
 							backgroundColor = text_config.textColor * {1, 1, 1, 0.25},
 						},
 						) {
-							if time.since(ctx.prev_event_time) > UI_EVENT_DELAY do ctx.statuses += {.EVENT}
+							if time.tick_since(ctx.prev_event_time) > UI_EVENT_DELAY do ctx.statuses += {.EVENT}
 						}
 					}
 

--- a/src/ui.odin
+++ b/src/ui.odin
@@ -493,6 +493,8 @@ UI_tick :: proc(
 				UI_DEBUG_PREV_TIME = time.now()
 			}
 		}
+	} else {
+		time.sleep(time.Millisecond / 10)
 	}
 
 	ctx.prev_frame_time = time.now()


### PR DESCRIPTION
moved to a multithreaded model where the gui, daemon, and controller all run in their own threads following the following pattern:
- controller runs on the main thread, this holds the global shortcuts, file watcher, and message passing
- daemon runs the daemon and its processes. this has been moved to a pipewire loop vs a threaded pipewire loop
- gui runs the gui and has changes to prevent maximize issues

this also makes the move to pipewire 1.4 so that `pw_loop_invoke` can be called without having to go through manual macro expansion